### PR TITLE
fix: optimizations are required to build

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -2,7 +2,9 @@
 src = 'src'
 out = 'out'
 libs = ['lib']
+
 via_ir = true
+optimizer = true
 
 # workaround for stack too deep errors with 0.8.26 https://github.com/ethereum/solidity/issues/14358
 solc = "0.8.25"


### PR DESCRIPTION
In foundry 0.3.0, the optimizer is off by default:
https://github.com/foundry-rs/foundry/pull/9657

but without the optimizer, the build fails with `Yul exception:Cannot swap Variable usr$c1 with Variable usr$r6: too deep in the stack`